### PR TITLE
Update podxmlgen to comply with the PSP-1 standard by the Podcast Standards Project

### DIFF
--- a/podxmlgen
+++ b/podxmlgen
@@ -163,7 +163,7 @@ _xml() {
 
 	cat <<XML
 <?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:itunesu="http://www.itunesu.com/feed" version="2.0">
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:itunesu="http://www.itunesu.com/feed" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
 	<channel>
 		<link>$feed_rel</link>
 		<language>$feed_lang</language>


### PR DESCRIPTION
The current XML doesn't meet all the new [PSP-1 standard](https://github.com/Podcast-Standards-Project/PSP-1-Podcast-RSS-Specification) by the [Podcast Standards Project](https://podstandards.org/). This PR extends the script to meet these recommendations.

<img width="1105" height="786" alt="image" src="https://github.com/user-attachments/assets/4cd249b4-ee70-4d25-8258-b7007b7211e5" />